### PR TITLE
Add basic caching of metricflow calls

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,8 @@ dependencies = [
     "dbt-core>=1.6.0",
     "dbt-metricflow>=0.6.0",
     "click>=7.1",
-    "yaspin>=2"
+    "yaspin>=2",
+    "joblib>=1.4.2"
 ]
 readme = "README.md"
 requires-python = ">= 3.10"

--- a/src/dbt_metric_utils/helpers.py
+++ b/src/dbt_metric_utils/helpers.py
@@ -1,4 +1,6 @@
+import hashlib
 import regex
+import json
 
 # Constant for the regex pattern to extract materialize calls.
 MATERIALIZE_CALL_PATTERN = regex.compile(r"""( # Capture group for the whole match.
@@ -14,6 +16,28 @@ MATERIALIZE_CALL_PATTERN = regex.compile(r"""( # Capture group for the whole mat
 """, regex.VERBOSE)
 
 
-def _extract_materialize_calls(raw_code):
+def extract_materialize_calls(raw_code):
     matches = MATERIALIZE_CALL_PATTERN.findall(raw_code)
     return matches
+
+
+def compute_file_hash(filenames):
+    m = hashlib.md5()
+    for filename in sorted(filenames):
+        with open(filename, 'rb') as f:
+            m.update(f.read())
+    return m.hexdigest()
+
+
+def _compute_dict_str_for_hash(d):
+    """
+    Create a caching hash for a dict by sorting the keys and dumping to string
+    """
+    return json.dumps(d, sort_keys=True, ensure_ascii=False)
+
+
+def compute_list_hash(dependencies):
+    """
+    Create a hash for caching a list of dicts by hashing the concatenation of the string representation of the dicts
+    """
+    return hashlib.md5("".join([_compute_dict_str_for_hash(x) for x in dependencies]).encode('utf8')).hexdigest()

--- a/src/dbt_metric_utils/materialize_metrics.py
+++ b/src/dbt_metric_utils/materialize_metrics.py
@@ -10,7 +10,7 @@ from dbt_metric_utils.helpers import extract_materialize_calls, compute_list_has
 
 from joblib import Memory
 
-memory = Memory(location='./.cache', verbose=20)
+memory = Memory(location='./.cache', verbose=0)
 memory.reduce_size("3M")  # TODO: test this size
 
 
@@ -223,7 +223,7 @@ def _generate_metric_queries_and_update_manifest(dbt_target: Optional[str] = Non
     for node_id, materialize_call_str in materialize_calls:
         kwargs = _parse_function_call_kwargs(materialize_call_str)
         try: 
-            var_key, var_val = generate_metric_sql(mf, kwargs)
+            var_key, var_val = generate_metric_sql_outer_wrapper(mf, manifest, kwargs)
         except Exception as e:
             raise Exception(f"Error generating sql for {node_id}, for the following metric invocation:\n\n{materialize_call_str}")
             raise

--- a/tests/test_extraction_of_materialize_calls.py
+++ b/tests/test_extraction_of_materialize_calls.py
@@ -1,4 +1,4 @@
-from src.dbt_metric_utils.helpers import _extract_materialize_calls
+from src.dbt_metric_utils.helpers import extract_materialize_calls
 
 
 def test_dimension_in_call():
@@ -18,7 +18,7 @@ def test_dimension_in_call():
     )"""
     ]
 
-    actual_sql = _extract_materialize_calls(input_sql)
+    actual_sql = extract_materialize_calls(input_sql)
     assert expected_sql == actual_sql
 
 
@@ -43,5 +43,5 @@ def test_multiple_calls():
     )"""
     ]
 
-    actual_sql = _extract_materialize_calls(input_sql)
+    actual_sql = extract_materialize_calls(input_sql)
     assert expected_sql == actual_sql


### PR DESCRIPTION
This uses joblib.Memory to cache the calls to mf query in `generate_metric_sql` (which are slow, and would otherwise be recomputed for every dbt call)

This uses the state of the upstream metrics and semantic models (from the manifest) to create a input hash for the function call. This way, the cache will be used iff:
1. The input arguments are the same as an item in the cache
2. The state of the metrics and semantic models used are identical